### PR TITLE
Add a new deck to to the fixtures directory. Changed seeds.rb file to load all decks.

### DIFF
--- a/db/fixtures/music-flashcards.txt
+++ b/db/fixtures/music-flashcards.txt
@@ -1,0 +1,14 @@
+What band had a hit song in 1997 with Free To Decide?
+The Cranberries
+
+Which singer was the first to be inducted into both the Rock & Roll hall of fame and the country music hall of fame?
+Johnny Cash
+
+Who is the lead singer of REM?
+Michael Stype
+
+What are the first names of country duo Brooks and Dunn?
+Kix and Ronnie
+
+Who hosted the TV show Yo MTV Raps with Dr Dre?
+Ed Lover

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,12 +1,20 @@
-deck = Deck.create(name: 'Ruby')
-front = nil
-back = nil
+fixtures_path = APP_ROOT.join('db', 'fixtures')
 
-File.new("db/fixtures/ruby-flashcards.txt").readlines.each_with_index do |line, i|
-  if i % 3 == 0
-    front = line.chomp
-  elsif i % 3 == 1
-    back = line.chomp
-    Card.create(deck_id: deck.id, front: front, back: back)
-  end 
+fixtures_path.each_child do |entry|
+  deck_name = entry.basename('-*').to_s.capitalize
+
+  deck = Deck.create(name: deck_name)
+
+  front = nil
+  back = nil
+
+  File.new(entry).readlines.each_with_index do |line, i|
+    if i % 3 == 0
+      front = line.chomp
+    elsif i % 3 == 1
+      back = line.chomp
+      Card.create(deck_id: deck.id, front: front, back: back)
+    end
+  end
 end
+


### PR DESCRIPTION
Note that decks must be named in the format **deckname-flashcards.txt** for them to be properly loaded by  `rake db:seed`. See example files in the `fixtures` directory.
